### PR TITLE
Rename IReadRepository to IReadOnlyRepository

### DIFF
--- a/src/BasicRepos.csproj
+++ b/src/BasicRepos.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.0.0</Version>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <FileVersion>3.0.0.0</FileVersion>
+    <Version>3.0.0</Version>
     <Authors>Turner Bass</Authors>
     <Company>Astro Panda Studios</Company>
     <Copyright />

--- a/src/Interfaces/IReadOnlyRepository.cs
+++ b/src/Interfaces/IReadOnlyRepository.cs
@@ -11,7 +11,7 @@ namespace BasicRepos.Interfaces
     /// A Repository only able to read and query the underlying entities
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface IReadRepository<T> where T : class
+    public interface IReadOnlyRepository<T> where T : class
     {
         /// <summary>
         /// Allows for the internal entities to be queried with any type specifications

--- a/src/RepositoryBase.cs
+++ b/src/RepositoryBase.cs
@@ -14,7 +14,7 @@ namespace BasicRepos
     /// <see cref="IRepository{T}"/> to all of its derived repositories
     /// </summary>
     /// <typeparam name="T">The <see cref="Type"/> of entity this repository operates with</typeparam>    
-    public abstract class RepositoryBase<T> : IRepository<T>, IReadRepository<T>
+    public abstract class RepositoryBase<T> : IRepository<T>, IReadOnlyRepository<T>
             where T : class
     {
         /// <summary>


### PR DESCRIPTION
Renames IReadRepository to IReadOnlyRepository to match convention, introducing a breaking change and iterating version to 3. solves issue #5