### PR TITLE
Unify the Basic Repos namespaces

### DIFF
--- a/pipelines/publish-pipeline.yml
+++ b/pipelines/publish-pipeline.yml
@@ -10,6 +10,7 @@ steps:
 - template: pipelines-template.yml
 
 - task: DotNetCoreCLI@2
+  condition:  and(eq('${{ variables['Build.SourceBranchName']}}', 'main'), ne('${{ variables['Build.Reason']}}', 'PullRequest'))
   displayName: 'create NuGet package'
   inputs:
     command: pack
@@ -17,6 +18,7 @@ steps:
     arguments: '-o $(Build.ArtifactStagingDirectory)'
 
 - task: PublishBuildArtifacts@1
+  condition:  and(eq('${{ variables['Build.SourceBranchName']}}', 'main'), ne('${{ variables['Build.Reason']}}', 'PullRequest'))
   displayName: 'Publish Build Artifacts'
   inputs:
     pathToPublish: '$(Build.ArtifactStagingDirectory)' 

--- a/src/Interfaces/IKeyedReadRepository.cs
+++ b/src/Interfaces/IKeyedReadRepository.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BasicRepos.Interfaces
+namespace BasicRepos
 {
     /// <summary>
     /// A read-only key based repository

--- a/src/Interfaces/IKeyedRepository.cs
+++ b/src/Interfaces/IKeyedRepository.cs
@@ -1,7 +1,4 @@
-
-using BasicRepos.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace BasicRepos

--- a/src/Interfaces/IReadOnlyRepository.cs
+++ b/src/Interfaces/IReadOnlyRepository.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BasicRepos.Interfaces
+namespace BasicRepos
 {
     /// <summary>
     /// A Repository only able to read and query the underlying entities

--- a/src/Interfaces/IRepository.cs
+++ b/src/Interfaces/IRepository.cs
@@ -1,8 +1,5 @@
-using BasicRepos.Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace BasicRepos

--- a/src/KeyedRepositoryBase.cs
+++ b/src/KeyedRepositoryBase.cs
@@ -1,13 +1,12 @@
 
 
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using BasicRepos.Interfaces;
-using Microsoft.EntityFrameworkCore;
 
-namespace BasicRepos 
+namespace BasicRepos
 {
     public abstract class KeyedRepositoryBase<T, TKey> : RepositoryBase<T>, IKeyedRepository<T, TKey>, IKeyedReadRepository<T, TKey>
         where T : class, IKeyedEntity<TKey>

--- a/src/RepositoryBase.cs
+++ b/src/RepositoryBase.cs
@@ -1,10 +1,9 @@
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using BasicRepos.Interfaces;
-using Microsoft.EntityFrameworkCore;
 
 namespace BasicRepos
 {


### PR DESCRIPTION
- Add conditions to publishing pipeline to keep from pushing a package during a PR build
- Public APIs now are all under one `BasicRepos` namespace