### PR TITLE
Add support for updating detached entities

### DIFF
--- a/BasicRepos.sln
+++ b/BasicRepos.sln
@@ -7,6 +7,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicRepos", "src\BasicRepo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicRepos.Test", "tests\BasicRepos.Test.csproj", "{2285A2D3-E720-4E7C-8F5D-E050F46A7F02}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pipelines", "pipelines", "{A2B2F318-2218-4E54-A3EF-4D6696969D58}"
+	ProjectSection(SolutionItems) = preProject
+		pipelines\pipelines-template.yml = pipelines\pipelines-template.yml
+		pipelines\pr-pipeline.yml = pipelines\pr-pipeline.yml
+		pipelines\publish-pipeline.yml = pipelines\publish-pipeline.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/RepositoryBase.cs
+++ b/src/RepositoryBase.cs
@@ -151,6 +151,10 @@ namespace BasicRepos
         /// </summary>
         /// <param name="objects">The entities to be updated</param>
         /// <returns>A <see cref="Task"/> representing the work of updating and saving the entities</returns>
-        public virtual Task UpdateAsync(params T[] objects) => Db.SaveChangesAsync();
+        public virtual Task UpdateAsync(params T[] objects)
+        {
+            Entities.UpdateRange(objects);
+            return Db.SaveChangesAsync();
+        }
     }
 }

--- a/tests/Repositorty.Tests/KeylessRepositoryTest.cs
+++ b/tests/Repositorty.Tests/KeylessRepositoryTest.cs
@@ -3,6 +3,7 @@ using BasicRepos.Test.Setup;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -338,7 +339,9 @@ namespace BasicRepos.Test.RepositortyTests
         {
             // Arrange
             var mockDb = new Mock<TestDbContext>();
+            var mockSet = new Mock<DbSet<Trillig>>();
             mockDb.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+            mockDb.Setup(x => x.Set<Trillig>()).Returns(mockSet.Object);
             _db = mockDb.Object;
             sut = new KeylessRepository(_db);
 
@@ -346,6 +349,7 @@ namespace BasicRepos.Test.RepositortyTests
             await sut.UpdateAsync();
 
             mockDb.Verify(x => x.SaveChangesAsync(default), Times.Once());
+            mockSet.Verify(x => x.UpdateRange(It.IsAny<Trillig[]>()), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Fixes issue #7. 

`RepositoryBase.UpdateAsync()` now can update detached entities;