### PR TITLE
Dynamic Registration of DbContext DbSet Type Repositories

### DIFF
--- a/src/DefaultKeyedRepository.cs
+++ b/src/DefaultKeyedRepository.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BasicRepos
+{
+    public class DefaultKeyedRepository<TEntity, TKey, TContext> : KeyedRepositoryBase<TEntity, TKey>
+        where TEntity : class, IKeyedEntity<TKey>
+        where TKey : IEquatable<TKey>
+        where TContext : DbContext
+    {
+        public DefaultKeyedRepository(TContext db) : base(db)
+        {
+        }
+    }
+}

--- a/src/DefaultRepository.cs
+++ b/src/DefaultRepository.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace BasicRepos
+{
+    public class DefaultRepository<TEntity, TContext> : RepositoryBase<TEntity> 
+        where TEntity : class
+        where TContext : DbContext
+    {
+        public DefaultRepository(TContext db) : base(db)
+        {
+        }
+    }
+}

--- a/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace BasicRepos
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddBasicRepos(this IServiceCollection services, params DbContext[] dbContexts)
+        {
+            return BindBasicRepos(services, dbContexts);
+        }
+
+        internal static IServiceCollection BindBasicRepos(IServiceCollection services, DbContext[] dbContexts)
+        {
+            Dictionary<DbContext, IEnumerable<Type>> entityTypeDictionary = new Dictionary<DbContext, IEnumerable<Type>>();
+
+            Type writeRepo = typeof(IRepository<>);
+            Type readRepo = typeof(IReadOnlyRepository<>);
+            Type writeKeyedRepo = typeof(IKeyedRepository<,>);
+            Type readKeyedRepo = typeof(IKeyedReadOnlyRepository<,>);
+            Type defaultRepo = typeof(DefaultRepository<,>);
+            Type defaultKeyedRepo = typeof(DefaultKeyedRepository<,,>);
+
+            foreach (var dbContext in dbContexts)
+            {
+                var types = dbContext.Model.GetEntityTypes();
+                entityTypeDictionary.Add(dbContext, types.Select(x => x.ClrType));
+            }
+
+            foreach(var entitymap in entityTypeDictionary)
+            {
+                Type dbContextType = entitymap.Key.GetType();
+
+                foreach (var entityType in entitymap.Value)
+                {
+                    Type concreteEntityType = entityType.GetType();
+                    services.TryAddTransient(writeRepo.MakeGenericType(concreteEntityType), defaultRepo.MakeGenericType(concreteEntityType, dbContextType));
+                    services.TryAddTransient(readRepo.MakeGenericType(concreteEntityType), defaultRepo.MakeGenericType(concreteEntityType, dbContextType));
+
+                    if(concreteEntityType.IsAssignableFrom(typeof(IKeyedEntity<>)))
+                    {
+                        PropertyInfo[] props = concreteEntityType.GetTypeInfo().GetProperties(BindingFlags.Public);
+                        PropertyInfo idProp = props.Where(x => x.Name == "Id").FirstOrDefault();
+
+                        if(idProp != null)
+                        {
+                            services.TryAddTransient(writeKeyedRepo.MakeGenericType(concreteEntityType), defaultRepo.MakeGenericType(concreteEntityType, idProp.PropertyType, dbContextType));
+                            services.TryAddTransient(writeKeyedRepo.MakeGenericType(concreteEntityType), defaultRepo.MakeGenericType(concreteEntityType, idProp.PropertyType, dbContextType));
+                        }
+                    }
+                }
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/ServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ namespace BasicRepos
                         if(idProp != null)
                         {
                             services.TryAddTransient(writeKeyedRepo.MakeGenericType(concreteEntityType), defaultRepo.MakeGenericType(concreteEntityType, idProp.PropertyType, dbContextType));
-                            services.TryAddTransient(writeKeyedRepo.MakeGenericType(concreteEntityType), defaultRepo.MakeGenericType(concreteEntityType, idProp.PropertyType, dbContextType));
+                            services.TryAddTransient(writeKeyedRepo.MakeGenericType(concreteEntityType), defaultKeyedRepo.MakeGenericType(concreteEntityType, idProp.PropertyType, dbContextType));
                         }
                     }
                 }

--- a/src/Interfaces/IKeyedReadOnlyRepository.cs
+++ b/src/Interfaces/IKeyedReadOnlyRepository.cs
@@ -11,7 +11,7 @@ namespace BasicRepos
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <typeparam name="TKey"></typeparam>
-    public interface IKeyedReadRepository<T, TKey>
+    public interface IKeyedReadOnlyRepository<T, TKey>
         where T : class, IKeyedEntity<TKey>
         where TKey : IEquatable<TKey>
     {

--- a/src/KeyedRepositoryBase.cs
+++ b/src/KeyedRepositoryBase.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace BasicRepos
 {
-    public abstract class KeyedRepositoryBase<T, TKey> : RepositoryBase<T>, IKeyedRepository<T, TKey>, IKeyedReadRepository<T, TKey>
+    public abstract class KeyedRepositoryBase<T, TKey> : RepositoryBase<T>, IKeyedRepository<T, TKey>, IKeyedReadOnlyRepository<T, TKey>
         where T : class, IKeyedEntity<TKey>
         where TKey : IEquatable<TKey>
     {

--- a/tests/BasicRepos.Test.csproj
+++ b/tests/BasicRepos.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/tests/Extensions/ServiceCollectionTest.cs
+++ b/tests/Extensions/ServiceCollectionTest.cs
@@ -1,0 +1,114 @@
+﻿using BasicRepos.Test.Setup;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BasicRepos.Test.Extensions
+{
+    public class ServiceCollectionTest
+    {
+        //private TestDbContext _db;
+        //private DbContextOptions<TestDbContext> _dbOptions = new D
+
+        private void ScaffoldDbContextConfiguration()
+        {
+
+        }
+    
+        [Fact]
+        public void AddBasicRepos_WithDbContext_registers_an_IRepository_ForeachDbset()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            services.AddDbContext<TestDbContext>(opts => opts.UseInMemoryDatabase("lolcat"));
+
+            // Act
+            services.AddBasicRepos<TestDbContext>();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            
+            // Assert
+            IRepository<Trillig> trilligRepo = serviceProvider.GetService<IRepository<Trillig>>();
+            Assert.NotNull(trilligRepo);
+
+            IRepository<Brillig> brilligRepo = serviceProvider.GetService<IRepository<Brillig>>();
+            Assert.NotNull(brilligRepo);
+
+            IRepository<Moamrath> moamrathRepo = serviceProvider.GetService<IRepository<Moamrath>>();
+            Assert.NotNull(moamrathRepo);
+        }
+
+
+        [Fact]
+        public void AddBasicRepos_WithDbContext_registers_an_IReadOnlyRepository_ForeachDbset()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            services.AddDbContext<TestDbContext>(opts => opts.UseInMemoryDatabase("lolcat"));
+
+            // Act
+            services.AddBasicRepos<TestDbContext>();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            IReadOnlyRepository<Trillig> trilligRepo = serviceProvider.GetService<IReadOnlyRepository<Trillig>>();
+            Assert.NotNull(trilligRepo);
+
+            IReadOnlyRepository<Brillig> brilligRepo = serviceProvider.GetService<IReadOnlyRepository<Brillig>>();
+            Assert.NotNull(brilligRepo);
+
+            IReadOnlyRepository<Moamrath> moamrathRepo = serviceProvider.GetService<IReadOnlyRepository<Moamrath>>();
+            Assert.NotNull(moamrathRepo);
+        }
+
+
+        [Fact]
+        public void AddBasicRepos_WithDbContext_registers_an_IKeyedRepository_ForeachDbset()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            services.AddDbContext<TestDbContext>(opts => opts.UseInMemoryDatabase("lolcat"));
+
+            // Act
+            services.AddBasicRepos<TestDbContext>();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            var trilligRepo = serviceProvider.GetService<IKeyedRepository<Trillig, int>>();
+            Assert.NotNull(trilligRepo);
+
+            var brilligRepo = serviceProvider.GetService<IKeyedRepository<Brillig, string>>();
+            Assert.NotNull(brilligRepo);
+
+            var moamrathRepo = serviceProvider.GetService<IKeyedRepository<Moamrath, Guid>>();
+            Assert.NotNull(moamrathRepo);
+        }
+
+        [Fact]
+        public void AddBasicRepos_WithDbContext_registers_an_IKeyedReadOnlyRepository_ForeachDbset()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            services.AddDbContext<TestDbContext>(opts => opts.UseInMemoryDatabase("lolcat"));
+
+            // Act
+            services.AddBasicRepos<TestDbContext>();
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            var trilligRepo = serviceProvider.GetService<IKeyedReadOnlyRepository<Trillig, int>>();
+            Assert.NotNull(trilligRepo);
+
+            var brilligRepo = serviceProvider.GetService<IKeyedReadOnlyRepository<Brillig, string>>();
+            Assert.NotNull(brilligRepo);
+
+            var moamrathRepo = serviceProvider.GetService<IKeyedReadOnlyRepository<Moamrath, Guid>>();
+            Assert.NotNull(moamrathRepo);
+        }
+
+    }
+}

--- a/tests/Setup/TestDbContext.cs
+++ b/tests/Setup/TestDbContext.cs
@@ -7,12 +7,17 @@ namespace BasicRepos.Test.Setup
 {
     public class TestDbContext : DbContext
     {
-        public TestDbContext() : this(new DbContextOptions<TestDbContext>())
+        public TestDbContext() : this(new DbContextOptionsBuilder<TestDbContext>())
         {
 
         }
 
         public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+        {
+
+        }
+
+        public TestDbContext(DbContextOptionsBuilder<TestDbContext> builder) : this(builder.Options)
         {
 
         }
@@ -52,6 +57,5 @@ namespace BasicRepos.Test.Setup
                 new Moamrath() { Id = Guid.Parse("ABABF0EA-4128-4830-8471-B634585145D9"), Sound = "In quantum mechanics, the uncertainty principle (also known as Heisenberg's uncertainty principle) is any of a variety of mathematical inequalities[1] asserting a fundamental limit to the precision with which the values for certain pairs of physical quantities of a particle, such as position, x, and momentum, p, can be predicted from initial conditions", Legs = 40 }
             });
         }
-
     }
 }


### PR DESCRIPTION
- Resolves issue #6 
- Provides a Service Collection Extension to register Repository services per a `DbContext` type
   - DefaultRepository
     - IReadOnlyRepository
     - IRepository
   - DefaultKeyedRepository
     - IKeyedReadOnlyRepository
     - IKeyedRepository
  
- Renamed `IKeyedReadRepository` to `IKeyedReadOnlyRepository`  