### PR TITLE
Remove need for parameterless constructor on DbContexts for Adding BasicRepos to service collection

### DIFF
--- a/.github/workflows/basic-repos.yml
+++ b/.github/workflows/basic-repos.yml
@@ -47,4 +47,4 @@ jobs:
     - name: Publish ${{ inputs.package_name }}
       if: (github.ref_name == 'main' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
       run: |-        
-        dotnet nuget push "**/*.nupkg" -s github
+        dotnet nuget push ${{ runner.temp }}/*.nupkg -s github

--- a/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/ServiceCollectionExtensions.cs
@@ -10,12 +10,12 @@ namespace BasicRepos;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddBasicRepos<TContext>(this IServiceCollection services) where TContext : DbContext, new()
+    public static IServiceCollection AddBasicRepos<TContext>(this IServiceCollection services) where TContext : DbContext
     {
         return ScaffoldBasicRepos<TContext>(services);
     }
 
-    public static IServiceCollection ScaffoldBasicRepos<TContext>(IServiceCollection services) where TContext : DbContext, new()
+    public static IServiceCollection ScaffoldBasicRepos<TContext>(IServiceCollection services) where TContext : DbContext
     {
         var serviceProvider = services.BuildServiceProvider();
         TContext dbContext = serviceProvider.GetRequiredService<TContext>();

--- a/tests/Repositorty.Tests/KeylessRepositoryTest.cs
+++ b/tests/Repositorty.Tests/KeylessRepositoryTest.cs
@@ -331,7 +331,7 @@ namespace BasicRepos.Test.RepositortyTests
         [InlineData(5)]
         public async Task DeleteAsync_RemovesValues_FromStore(int id)
         {
-            var mockDb = new Mock<TestDbContext>();
+            var mockDb = new Mock<TestDbContext>(new DbContextOptionsBuilder<TestDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
             var mockSet = new Mock<DbSet<Trillig>>();
             var trilligList = _db.Trilligs.ToList();
 
@@ -354,7 +354,7 @@ namespace BasicRepos.Test.RepositortyTests
         public async Task UpdateAsync_SimplyCalls_DbSaveChangesAsync()
         {
             // Arrange
-            var mockDb = new Mock<TestDbContext>();
+            var mockDb = new Mock<TestDbContext>(new DbContextOptionsBuilder<TestDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
             var mockSet = new Mock<DbSet<Trillig>>();
             mockDb.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
             mockDb.Setup(x => x.Set<Trillig>()).Returns(mockSet.Object);

--- a/tests/Setup/TestDbContext.cs
+++ b/tests/Setup/TestDbContext.cs
@@ -7,17 +7,7 @@ namespace BasicRepos.Test.Setup
 {
     public class TestDbContext : DbContext
     {
-        public TestDbContext() : this(new DbContextOptionsBuilder<TestDbContext>())
-        {
-
-        }
-
         public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
-        {
-
-        }
-
-        public TestDbContext(DbContextOptionsBuilder<TestDbContext> builder) : this(builder.Options)
         {
 
         }


### PR DESCRIPTION
- Removing the parameterless constructor from the generic type parameter of `AddBasicRepos` is not a breaking change. Current consuming applications should not even need to make any changes for the service collection to keep working.

This change enables the consuming application to have full control over how DbContexts are instantiated since we're already pulling from the service collection to get an instance.